### PR TITLE
ForImage dependency

### DIFF
--- a/example/demo.f90
+++ b/example/demo.f90
@@ -46,21 +46,21 @@ program demo
     ! The built-in z=f(x,y) test function is in the [0, 2] range:
     do i = 1, size(colormaps_list)
         call cmap%set(trim(colormaps_list(i)), 0.0_wp, 2.0_wp)
-        call cmap%test()
+        call cmap%test(encoding='binary')
         print '("Colormap ", A30, " has ", I0, " levels")', trim(cmap%get_current()), cmap%get_levels()
     end do
 
     ! Cubehelix can also accept other paramaters (varargs array):
     call cmap%set("cubehelix", 0.0_wp, 2.0_wp, 1024, [0.5_wp, -1.0_wp, 1.0_wp, 1.0_wp])
     ! We change the name for the output test files:
-    call cmap%test("cubehelix_customized")
+    call cmap%test("cubehelix_customized", encoding='binary')
 
     ! You can create your own colormap defined in an array:
     call custom_cmap%create("discrete", 0.0_wp, 2.0_wp, my_colormap)
-    call custom_cmap%test()
+    call custom_cmap%test(encoding='binary')
 
     ! Or you can download it from a .txt file:
     call custom_cmap%load("test_map_to_load.txt", 0.0_wp, 2.0_wp)
-    call custom_cmap%test("a_loaded_colormap")
+    call custom_cmap%test("a_loaded_colormap", encoding='binary')
     call custom_cmap%print()
 end program demo

--- a/example/example1.f90
+++ b/example/example1.f90
@@ -1,0 +1,29 @@
+program example1
+    use forcolormap
+    use forimage
+    implicit none
+
+    type(Colormap) :: custom_cmap
+    type(format_pnm) :: ex1_colormap, ex1_colorbar
+
+    ! Create ppm files
+    call custom_cmap%load("test_map_to_load.txt", 0.0_wp, 2.0_wp)
+    call custom_cmap%test("a_loaded_colormap_ascii", 'ascii')
+    call custom_cmap%print()
+
+    ! Import ascii ppm files
+    call ex1_colormap%import_pnm('a_loaded_colormap_ascii_test','ppm', 'ascii')
+    call ex1_colorbar%import_pnm('a_loaded_colormap_ascii_colorbar','ppm', 'ascii')
+   
+    ! Change colormap and colorbar colors
+    ex1_colormap%pixels = ex1_colormap%pixels * (1.6)
+    ex1_colorbar%pixels = ex1_colorbar%pixels * (1.6)
+
+    ! Export binary ppm files
+    call ex1_colormap%export_pnm('a_loaded_colormap_binary_test_m', 'binary')
+    call ex1_colorbar%export_pnm('a_loaded_colormap_binary_colorbar_m', 'binary')
+
+    ! Deallocate
+    call ex1_colormap%finalize()
+    call ex1_colorbar%finalize()
+end program example1

--- a/fpm.toml
+++ b/fpm.toml
@@ -9,15 +9,23 @@ homepage   = "https://github.com/vmagnin/forcolormap"
 categories = ["graphics"]
 keywords   = ["Fortran", "fpm", "colormap"]
 
+[dependencies]
+forimage = {git="https://github.com/gha3mi/forimage.git"}
+
 [[example]]
-name = "example"
+name = "demo"
 source-dir = "example"
 main = "demo.f90"
+
+[[example]]
+name = "example1"
+source-dir = "example"
+main = "example1.f90"
 
 [build]
 auto-executables = true
 auto-tests = true
-auto-examples = true
+auto-examples = false
 module-naming = false
 
 [install]


### PR DESCRIPTION
Hello @vmagnin,

This PR addresses issue #1 and includes the following changes:

- Added `ForImage` as a dependency for `ForColormap`.
- Introduced a new example, `example1`, to demonstrate the import and export functionality of `ForImage`.
- Modified the `demo.f90` file.
- Updated `fpm.toml` configurations.

Feel free to make any further modifications to this PR.

Thanks,
Ali