### PR TITLE
Update fpm.yml to include nvidia-hpc compiler

### DIFF
--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -19,15 +19,18 @@ jobs:
           - {compiler: gcc}
           - {compiler: intel}
           - {compiler: intel-classic}
+          - {compiler: nvidia-hpc}
         exclude:
           - os: windows-latest
             toolchain: {compiler: intel}
           - os: windows-latest
             toolchain: {compiler: intel-classic}
+          - os: windows-latest
+            toolchain: {compiler: nvidia-hpc}
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 


### PR DESCRIPTION
Hi @vmagnin

This PR includes the NVIDIA compiler in the CI for fpm.

It also updates the Checkout action to the latest version, v4.

Thanks
Ali