### PR TITLE
Clean up for WIN32 and shared library

### DIFF
--- a/cmake/dependencies/forimage/CMakeLists.txt
+++ b/cmake/dependencies/forimage/CMakeLists.txt
@@ -10,16 +10,6 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(forimage)
 
-if (WIN32)
-    if (BUILD_SHARED_LIBS)
-        add_custom_command(
-            TARGET ${PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:forimage>
-            $<TARGET_FILE_DIR:${PROJECT_NAME}
-        )
-    endif()
-endif()
 
 set(forimage_INCLUDE_DIR ${forimage_BINARY_DIR}/include)
 set(forimage_INCLUDE_DIR ${forimage_INCLUDE_DIR} PARENT_SCOPE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,17 @@ function(build_test test_name src)
         WORKING_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
         COMMAND $<TARGET_FILE:${test_name}>
     )
+
+    if (${BUILD_SHARED_LIBS} AND WIN32)
+        add_custom_command(
+            TARGET ${test_name}
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+            $<TARGET_RUNTIME_DLLS:${test_name}>
+            $<TARGET_FILE_DIR:${test_name}>
+            COMMAND_EXPAND_LISTS
+        )
+    endif()
 endfunction()
 
 build_test(check check.f90)


### PR DESCRIPTION
I've fixed an issue I encountered when trying to use this library from a Windows machine and building as a shared library using CMake.  Tests pass on my Windows machine, so I think all is well on the CMake side; however, there does appear to be an issue with the CI workflow for FPM.  I'm a bit less familiar with the FPM side of things, so I've left that untouched.  