### PR TITLE
revert nvfortran compatibility workaround (fixes #40)

### DIFF
--- a/src/colormap_class.f90
+++ b/src/colormap_class.f90
@@ -37,7 +37,7 @@ module forcolormap
     public :: wp
 
     !> List of built-in colormaps:
-    character(*), dimension(6+222+4), public, parameter :: colormaps_list = &
+    character(*), dimension(*), public, parameter :: colormaps_list = &
         [character(colormap_name_length) :: &
         miscellaneous_colormaps_list,&
         scientific_colour_maps_list,&

--- a/src/matplotlib_colormaps.f90
+++ b/src/matplotlib_colormaps.f90
@@ -37,7 +37,7 @@ module matplotlib_colormaps
     implicit none
     private
 
-    character(*), dimension(4), parameter, public :: matplotlib_colormaps_list = &
+    character(*), dimension(*), parameter, public :: matplotlib_colormaps_list = &
         [character(colormap_name_length) :: &
         "magma", "inferno","plasma", "viridis"]
 

--- a/src/miscellaneous_colormaps.f90
+++ b/src/miscellaneous_colormaps.f90
@@ -33,7 +33,7 @@ module miscellaneous_colormaps
     public :: fire_colormap, rainbow_colormap, &
               inv_rainbow_colormap, zebra_colormap, cubehelix_colormap
 
-    character(*), dimension(6), parameter, public :: miscellaneous_colormaps_list = &
+    character(*), dimension(*), parameter, public :: miscellaneous_colormaps_list = &
         [character(colormap_name_length) :: &
         "fire", "rainbow", "inv_rainbow", "zebra", "cubehelix", &
         "black_body"]

--- a/src/scientific_colour_maps.f90
+++ b/src/scientific_colour_maps.f90
@@ -29,7 +29,7 @@ module scientific_colour_maps
     implicit none
     private
 
-    character(*), dimension(222), parameter, public :: scientific_colour_maps_list = &
+    character(*), dimension(*), parameter, public :: scientific_colour_maps_list = &
         [character(colormap_name_length) :: &
         "acton", "acton10", "acton100", "acton25", "acton50", "actonS", &
         "bam", "bam10", "bam100", "bam25", "bam50", "bamako", &


### PR DESCRIPTION
@vmagnin, this PR reverts the temporary nvfortran compatibility workaround introduced in commit b7e6154.
